### PR TITLE
Include postdate in Mapping

### DIFF
--- a/src/services/Indexes.php
+++ b/src/services/Indexes.php
@@ -461,16 +461,21 @@ class Indexes extends Component
         $mapping = [];
 
         $predefinedAttributes = [
-            'title' => 'text',
-            'slug' => 'text',
-            'postDate' => 'date'
+            'title' => [
+                'type' => 'text',
+                'analyzer' => 'standard',
+            ],
+            'slug' => [
+                'type' => 'text',
+                'analyzer' => 'standard',
+            ],
+            'postDate' => [
+                'type' => 'date',
+            ],
         ];
 
-        foreach ($predefinedAttributes as $attribute => $type) {
-            $mapping[$fieldPrefix . 'attribute_' . $attribute] = [
-                'type' => $type,
-                'analyzer' => 'standard',
-            ];
+        foreach ($predefinedAttributes as $attribute => $config) {
+            $mapping[$fieldPrefix . 'attribute_' . $attribute] = $config;
         }
 
         /**

--- a/src/services/Indexes.php
+++ b/src/services/Indexes.php
@@ -461,13 +461,14 @@ class Indexes extends Component
         $mapping = [];
 
         $predefinedAttributes = [
-            'title',
-            'slug',
+            'title' => 'text',
+            'slug' => 'text',
+            'postDate' => 'date'
         ];
 
-        foreach ($predefinedAttributes as $attribute) {
+        foreach ($predefinedAttributes as $attribute => $type) {
             $mapping[$fieldPrefix . 'attribute_' . $attribute] = [
-                'type' => 'text',
+                'type' => $type,
                 'analyzer' => 'standard',
             ];
         }

--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -71,6 +71,10 @@ class Search extends CraftSearch
             $keywords['attribute_' . $attribute] = $element->getSearchKeywords($attribute);
         }
 
+        if(isset($element->postDate) && $element->postDate instanceof \DateTime) {
+            $keywords['attribute_postDate'] = $element->postDate->format(\DateTime::ATOM);
+        }
+
         // Update the custom fields' keywords
         foreach ($updateFields as $field) {
             $fieldValue = $element->getFieldValue($field->handle);


### PR DESCRIPTION
Adds the postDate to the index. If it is in the index,  you can for instance customize the query make more recent entries more relevant, rather than using the craft's date sort that will ignore orther ranking factors.