### PR TITLE
Feature/before query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Elasticsearch Plugin
 
+## Unreleased
+
+### Added
+- Event to manipulate the search parameters before querying Elasticsearch.
+
 ## 1.2.0 - 2022-06-15
 
 ### Added

--- a/src/events/BeforeQueryEvent.php
+++ b/src/events/BeforeQueryEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace codemonauts\elastic\events;
+
+use yii\base\Event;
+
+class BeforeQueryEvent extends Event
+{
+    /**
+     * @var array The params that will be sent to Elasticsearch.
+     */
+    public array $params = [];
+}

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3,6 +3,7 @@
 namespace codemonauts\elastic\services;
 
 use codemonauts\elastic\Elastic;
+use codemonauts\elastic\events\BeforeQueryEvent;
 use craft\base\Component;
 use craft\base\ElementInterface;
 use craft\models\Site;
@@ -17,6 +18,11 @@ use yii\base\InvalidConfigException;
  */
 class Elements extends Component
 {
+    /**
+     * @event BeforeQueryEvent The event that is triggered before the query is sent to ELasticsearch.
+     */
+    public const EVENT_BEFORE_QUERY = 'beforeQuery';
+
     /**
      * Adds the keywords of an element to the Elasticsearch index of a site.
      *
@@ -157,6 +163,14 @@ class Elements extends Component
                 ],
             ];
         }
+
+        // Allow plugins to modify the query parameters
+        $event = new BeforeQueryEvent([
+            'params' => $params,
+        ]);
+        $this->trigger(self::EVENT_BEFORE_QUERY, $event);
+        $params = $event->params;
+
 
         return Elastic::$plugin->getElasticsearch()->getClient()->search($params);
     }


### PR DESCRIPTION
Adds the before query event that was added to the Craft 4 version, but was missing for Craft 3